### PR TITLE
Ajuste mensagem de cashback

### DIFF
--- a/src/services/whatsapp.ts
+++ b/src/services/whatsapp.ts
@@ -176,8 +176,9 @@ export class WhatsApp {
       callback?: (voucher: VoucherNotification) => void
     ) => {
       for await (const voucher of list) {
+        const contact = this.checkNinthDigit(`55${voucher.client.whatsapp}`)
         await this.bot.sendMessage(
-          `55${voucher.client.whatsapp}@c.us`,
+          contact._serialized,
           botMessages.cashback[messageType]({ voucher, profile })
         );
         callback(voucher);


### PR DESCRIPTION
Envio de mensagem de cashback sem o 9 digito para DDDs maiores que 28