### PR TITLE
chore: atualizando Electron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
         "@vitest/coverage-v8": "^1.6.0",
         "@vitest/ui": "^1.6.0",
         "autoprefixer": "^10.4.19",
-        "electron": "^30.0.1",
+        "electron": "^31.2.0",
         "electron-is-dev": "^3.0.1",
         "eslint": "^8.0.1",
         "eslint-plugin-import": "^2.25.0",
@@ -5116,9 +5116,9 @@
       "dev": true
     },
     "node_modules/electron": {
-      "version": "30.0.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-30.0.1.tgz",
-      "integrity": "sha512-iwxkI/n2wBd29NH7TH0ZY8aWGzCoKpzJz+D10u7aGSJi1TV6d4MSM3rWyKvT/UkAHkTKOEgYfUyCa2vWQm8L0g==",
+      "version": "31.2.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-31.2.0.tgz",
+      "integrity": "sha512-5w+kjOsGiTXytPSErBPNp/3znnuEMKc42RD41MqRoQkiYaR8x/Le2+qWk1cL60UwE/67oeKnOHnnol8xEuldGg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@vitest/coverage-v8": "^1.6.0",
     "@vitest/ui": "^1.6.0",
     "autoprefixer": "^10.4.19",
-    "electron": "^30.0.1",
+    "electron": "^31.2.0",
     "electron-is-dev": "^3.0.1",
     "eslint": "^8.0.1",
     "eslint-plugin-import": "^2.25.0",


### PR DESCRIPTION
A versão do Electron foi atualizada. Com essa atualização foi resolvido o BUG que contia no Electron que não funcionava o input type file 